### PR TITLE
Include packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,5 @@ setup(
     install_requires=['requests>=2.4.3'],
     tests_require=['unittest'],
     entry_points={},
+    packages=['mailjet'],
 )


### PR DESCRIPTION
As per [Packaging and Distributing Projects](http://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#packages), it is required to list the packages to be included in your project.

Otherwise, `pip install` git repo doesn’t work:

```
$ pip install "git+https://github.com/mailjet/mailjet-apiv3-python.git#egg=mailjet_rest"
Downloading/unpacking mailjet-rest from git+https://github.com/mailjet/mailjet-apiv3-python.git
  Cloning https://github.com/mailjet/mailjet-apiv3-python.git to ./build/mailjet-rest
  Running setup.py (path:/private/tmp/boo/build/mailjet-rest/setup.py) egg_info for package mailjet-rest

Requirement already satisfied (use --upgrade to upgrade): requests>=2.4.3 in ./lib/python2.7/site-packages/requests-2.8.1-py2.7.egg (from mailjet-rest)
Installing collected packages: mailjet-rest
  Running setup.py install for mailjet-rest

Successfully installed mailjet-rest
Cleaning up...
$ python
Python 2.7.10 (default, Oct 23 2015, 18:05:06)
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mailjet
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named mailjet
>>> 
```