### PR TITLE
Fix mixed indent type

### DIFF
--- a/mailjet/client.py
+++ b/mailjet/client.py
@@ -52,7 +52,7 @@ class Endpoint(object):
 
     def update(self, id, data, filters=None, action_id=None, **kwargs):
         if self.headers['Content-type'] == 'application/json':
-			data = json.dumps(data)
+            data = json.dumps(data)
         return api_call(self._auth, 'put', self._url, resource_id=id, headers=self.headers, data=data, action=self.action, action_id=action_id, filters=filters, **kwargs)
 
     def delete(self, id, **kwargs):


### PR DESCRIPTION
"TabError: inconsistent use of tabs and spaces in indentation".

Fixed mixed indent type after previous commit f76bcb329f3a5c5fa99b0994f5fe7ff0b905744f.