### PR TITLE
action_id param included in _get call

### DIFF
--- a/mailjet_rest/client.py
+++ b/mailjet_rest/client.py
@@ -54,7 +54,7 @@ class Endpoint(object):
         return self._get(filters=filters, **kwargs)
 
     def get(self, id=None, filters=None, action_id=None, **kwargs):
-        return self._get(id=id, filters=filters, **kwargs)
+        return self._get(id=id, filters=filters, action_id=action_id, **kwargs)
 
     def create(self, data=None, filters=None, id=None, action_id=None, **kwargs):
         if self.headers['Content-type'] == 'application/json':


### PR DESCRIPTION
action_id param gets lost in get call so it is not possible to reference it.

I experienced the case trying to monitor a Job in a bulk contact management.