### PR TITLE
[FIX] get method returns 404

### DIFF
--- a/mailjet_rest/client.py
+++ b/mailjet_rest/client.py
@@ -51,10 +51,10 @@ class Endpoint(object):
         return api_call(self._auth, 'get', self._url, headers=self.headers, action=self.action, action_id=action_id, filters=filters, resource_id=id, **kwargs)
 
     def get_many(self, filters=None, action_id=None, **kwargs):
-        return self._get(filters=filters, **kwargs)
+        return self._get(filters=filters, action_id=action_id, **kwargs)
 
     def get(self, id=None, filters=None, action_id=None, **kwargs):
-        return self._get(id=id, filters=filters, **kwargs)
+        return self._get(id=id, filters=filters, action_id=action_id, **kwargs)
 
     def create(self, data=None, filters=None, id=None, action_id=None, **kwargs):
         if self.headers['Content-type'] == 'application/json':


### PR DESCRIPTION
Hi Mailjet Team,
we found an issue with get method and with this pull request we want to solve it.
This pull request solves problem with get method returning 404 due to missing action_id parameter.

Kind regards,
Modoolar team