### PR TITLE
Support V4 API

### DIFF
--- a/mailjet_rest/client.py
+++ b/mailjet_rest/client.py
@@ -33,7 +33,7 @@ class Config(object):
         elif key.lower() == 'batchjob_csverror':
             url = urljoin(url, 'DATA/')
             headers['Content-type'] = 'text/csv'
-        elif key.lower() != 'send':
+        elif key.lower() != 'send' and self.version != 'v4':
             url = urljoin(url, 'REST/')
         url = url + key.split('_')[0].lower()
         return url, headers


### PR DESCRIPTION
API V4 has a different URL format than the older versions, namely [it drops the `/REST/` URL fragment](https://dev.mailjet.com/email/guides/contact-management/#gdpr-delete-contacts).
This PR adds support for this new format.