### PR TITLE
Update test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -72,7 +72,7 @@ class TestSuite(unittest.TestCase):
 
     def test_post_with_no_param(self):
         result = self.client.sender.create(data={}).json()
-        self.assertTrue('StatusCode' in result and result['StatusCode'] is not 400)
+        self.assertTrue('StatusCode' in result and result['StatusCode'] == 400)
 
     def test_client_custom_version(self):
         self.client = Client(


### PR DESCRIPTION
https://github.com/mailjet/mailjet-apiv3-python/issues/53

The expected result is:
{'ErrorInfo': 'MJ08 Property Email is invalid: MJ03 A non-empty value is required', 'ErrorMessage': 'Object properties invalid', 'StatusCode': 400}
So if we will change "is not" to "!=" it will raise an error:
AssertionError: False is not true
So here we should change it to "=="