### PR TITLE
Corrected url building bug

### DIFF
--- a/mailjet_rest/client.py
+++ b/mailjet_rest/client.py
@@ -139,13 +139,12 @@ def build_headers(resource, action=None, extra_headers=None):
 
 
 def build_url(url, method, action=None, resource_id=None, action_id=None):
-    if resource_id:
-        url += '/%s' % str(resource_id)
     if action:
         url += '/%s' % action
         if action_id:
             url += '/{}'.format(action_id)
-
+    if resource_id:
+        url += '/%s' % str(resource_id)
     return url
 
 


### PR DESCRIPTION
Hello,

When using this package i've encoutered a bug affecting the URL Builder when access endpoint needing a ressource_id and an action_id. The resource_id and action_id are reversed when building the URL.

You can reproduce this error when accessing mailjet.contact_managemanycontacts.get(jobID) if you need.

  - URL built before correction : MAILJET_API_URL/endpoint/ressource_id/action_id
     - example : MAILJET_API_URL/contact/123456/managemanycontacts

  - URL built after correction : MAILJET_API_URL/contact/action_id/ressource_id
     - example : /contact/managemanycontacts/123456