### PR TITLE
dnefodov: Add ensure_ascii check disabling

### DIFF
--- a/mailjet_rest/client.py
+++ b/mailjet_rest/client.py
@@ -64,14 +64,20 @@ class Endpoint(object):
     def get(self, id=None, filters=None, action_id=None, **kwargs):
         return self._get(id=id, filters=filters, action_id=action_id, **kwargs)
 
-    def create(self, data=None, filters=None, id=None, action_id=None, **kwargs):
+    def create(self, data=None, filters=None, id=None, action_id=None, ensure_ascii=True, data_encoding="utf-8", **kwargs):
         if self.headers['Content-type'] == 'application/json':
-            data = json.dumps(data)
+            if ensure_ascii:
+                data = json.dumps(data)
+            else:
+                data = json.dumps(data, ensure_ascii=False).encode(data_encoding)
         return api_call(self._auth, 'post', self._url, headers=self.headers, resource_id=id, data=data, action=self.action, action_id=action_id, filters=filters, **kwargs)
 
-    def update(self, id, data, filters=None, action_id=None, **kwargs):
+    def update(self, id, data, filters=None, action_id=None, ensure_ascii=True, data_encoding="utf-8", **kwargs):
         if self.headers['Content-type'] == 'application/json':
-            data = json.dumps(data)
+            if ensure_ascii:
+                data = json.dumps(data)
+            else:
+                data = json.dumps(data, ensure_ascii=False).encode(data_encoding)
         return api_call(self._auth, 'put', self._url, resource_id=id, headers=self.headers, data=data, action=self.action, action_id=action_id, filters=filters, **kwargs)
 
     def delete(self, id, **kwargs):


### PR DESCRIPTION
Enables possibility to disable non-ascii characters skip which is default for python `json.dumps` build-in function.

Possible ways to use: 
```python
data = {
    "Locale": "en_US",
    "Sender": os.environ["Sender"],
    "SenderEmail": os.environ["SenderEmail"],
    "SenderName": "Name 😊❤️✨👣🐱🐶😊🥹",
    "Subject": "Subject 😊❤️✨👣🐱🐶😊🥹",
    "Title": "Title 😊❤️✨👣🐱🐶😊🥹",
    "ContactsListID": os.environ["ContactsListID"],
}
mailjet.campaigndraft.create(data=data, ensure_ascii=False)
```
With `ensure_ascii=False` flag none of emojis will be skipped.