### PR TITLE
Update license in setup.py to confirm LICENSE file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     classifiers=['Development Status :: 4 - Beta',
                  'Environment :: Console',
                  'Intended Audience :: Developers',
-                 'License :: OSI Approved :: GNU General Public License (GPL)',
+                 'License :: The MIT License (MIT)',
                  'Natural Language :: English',
                  'Operating System :: OS Independent',
                  'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
In the license file it says MIT license. 

We use automated license checkers and this package was flagged as a copy left package.

Apparently 10 years ago nobody cared about licenses haha
![image](https://github.com/mailjet/mailjet-apiv3-python/assets/51402920/96324089-6fc7-472b-a8ea-eb47cc6b5411)
